### PR TITLE
do not detect tableau variables as secrets

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -1964,7 +1964,7 @@ stopwords = [
 regexTarget = "line"
 regexes = [
     '''arn:aws:secretsmanager:[a-z0-9-]+:\d{12}:secret:[\w+=,.@/-]+''',
-    '"tableau[^"]*"\s*:\s*".*?"'
+    '''tableau'''
 ]
 
 [[rules]]

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -1964,7 +1964,10 @@ stopwords = [
 regexTarget = "line"
 regexes = [
     '''arn:aws:secretsmanager:[a-z0-9-]+:\d{12}:secret:[\w+=,.@/-]+''',
-    '''tableau'''
+]
+
+paths = [
+    '''.*\/tableau_.*\.json$''',
 ]
 
 [[rules]]

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -1963,7 +1963,8 @@ stopwords = [
 
 regexTarget = "line"
 regexes = [
-    '''arn:aws:secretsmanager:[a-z0-9-]+:\d{12}:secret:[\w+=,.@/-]+'''
+    '''arn:aws:secretsmanager:[a-z0-9-]+:\d{12}:secret:[\w+=,.@/-]+''',
+    '"tableau[^"]*"\s*:\s*".*?"'
 ]
 
 [[rules]]


### PR DESCRIPTION
### Description:

Make sure that tableau variables in json files are not marked as generic API keys

### Checklist:

* [ ] Have a json with tableau variables as key (eg. tableauPositionTranslationKey)
* [ ] Run gitleaks and see that the variable is no longer marked as a generic API key
