### PR TITLE
Allow '~' in generic-api-key secret

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -476,7 +476,7 @@ keywords = [
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=~]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = [
     "key","api","token","secret","client","passwd","password","auth","access",


### PR DESCRIPTION
### Description:

Allow '~' in generic-api-key secret

Context: Azure AD often adds ~ in its client secrets. These were undetected.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
