### PR TITLE
goreleaser: set CGO_ENABLED=0 for fully static binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,8 @@ builds:
       - "7"
     ldflags:
       - -s -w -X=github.com/AikidoSec/gitleaks/cmd.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
 archives:
   - builds: [gitleaks]
     format_overrides:


### PR DESCRIPTION

### Description:

Enables binaries that run on Alpine and other minimal images by building without cgo, producing fully statically linked executables.

Partially reverts https://github.com/AikidoSec/gitleaks/commit/f7eb03be76b791c764bbdbb3e29209af9f886c83

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Set CGO_ENABLED=0 in goreleaser config for static binaries


<sup>[More info](https://app.aikido.dev/featurebranch/scan/84768240?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->